### PR TITLE
Notifications sockets

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -5,7 +5,7 @@ import { AppBar, Toolbar, Button, Menu, MenuItem, Avatar, Badge } from "@materia
 import NotificationsIcon from "@material-ui/icons/Notifications";
 import UserContext from "context/UserContext";
 import CodeUploadDialog from 'pages/CodeUploadDialog';
-// import axios from "axios";
+import axios from "axios";
 
 import socket from "utils/socket";
 
@@ -65,6 +65,7 @@ const Navbar = () => {
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState({});
   const [notifications, setNotifications] = useState([]);
+  const [newNotification, setNewNotification] = useState([]);
 
   const handleUploadDialog = () => {
     setUploadDialogOpen(!uploadDialogOpen);
@@ -84,11 +85,22 @@ const Navbar = () => {
   };
 
   useEffect(() => {
-    socket.connect(localStorage.token);
-    socket.fetchNotifications(setNotifications);
+    // initialize socket connection
+    socket.connect(
+      localStorage.token,
+      setNewNotification,
+    );
+
+    // fetch all notifications for this user from db
+    (async function () {
+      const data = await socket.fetchNotifications();
+      setNotifications(data);
+    })()
   }, []);
 
-  console.log(notifications)
+  useEffect(() => {
+    setNotifications([newNotification, ...notifications]);
+  }, [newNotification]);
 
   return (
     <AppBar>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -5,6 +5,7 @@ import { AppBar, Toolbar, Button, Menu, MenuItem, Avatar, Badge } from "@materia
 import NotificationsIcon from "@material-ui/icons/Notifications";
 import UserContext from "context/UserContext";
 import CodeUploadDialog from 'pages/CodeUploadDialog';
+import axios from "axios";
 
 import socket from "utils/socket";
 
@@ -63,7 +64,7 @@ const Navbar = () => {
   const { user, logout } = useContext(UserContext);
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState({});
-  const [newNotifications, setNewNotifications] = useState(true);
+  const [notifications, setNotifications] = useState([]);
 
   const handleUploadDialog = () => {
     setUploadDialogOpen(!uploadDialogOpen);
@@ -84,7 +85,40 @@ const Navbar = () => {
 
   useEffect(() => {
     socket.connect(localStorage.token);
+
+    // TESTING CODE FOR CREATING A NOTIFICATION
+    // async function createTestNotification() {
+    //   try {
+    //     await axios.post("/api/notifications", {
+    //       recipient: "5e9cab170f8bc650e4b622c8",
+    //       code: 1,
+    //       title: "some title",
+    //     })
+    //   } catch (err) {
+    //     console.error(err);
+    //   }
+    // }
+    // createTestNotification();
+
+    async function getInitialNotifications() {
+      try {
+        const AuthStr = localStorage.token;
+        const { data } = await axios.get("/api/notifications", {
+          headers: { Authorization: "Bearer " + AuthStr },
+        });
+        return data;
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    async function setInitialNotifications() {
+      const data = await getInitialNotifications();
+      setNotifications(data);
+    }
+    setInitialNotifications();
   }, []);
+
+  console.log(notifications)
 
   return (
     <AppBar>
@@ -107,7 +141,7 @@ const Navbar = () => {
 
           <Button id="notifications" className={classes.clickable} onClick={handleMenu}>
             <Avatar className={classes.notification}>
-              <Badge color="secondary" variant="dot" invisible={!newNotifications}>
+              <Badge color="secondary" variant="dot" invisible={notifications.every(n => n.seen)}>
                 <NotificationsIcon />
               </Badge>
             </Avatar>
@@ -120,7 +154,7 @@ const Navbar = () => {
             onClose={handleClose}
           >
             <Notifications
-              setNewNotifications={setNewNotifications}
+              notifications={notifications}
             />
           </Menu>
           

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -3,9 +3,9 @@ import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import { AppBar, Toolbar, Button, Menu, MenuItem, Avatar, Badge } from "@material-ui/core";
 import NotificationsIcon from "@material-ui/icons/Notifications";
+import NotificationsNoneIcon from "@material-ui/icons/NotificationsNone";
 import UserContext from "context/UserContext";
 import CodeUploadDialog from 'pages/CodeUploadDialog';
-import axios from "axios";
 
 import socket from "utils/socket";
 
@@ -124,7 +124,11 @@ const Navbar = () => {
           <Button id="notifications" className={classes.clickable} onClick={handleMenu}>
             <Avatar className={classes.notification}>
               <Badge color="secondary" variant="dot" invisible={notifications.every(n => n.seen)}>
-                <NotificationsIcon />
+                {notifications.length ? (
+                  <NotificationsIcon />
+                ): (
+                  <NotificationsNoneIcon />
+                )}
               </Badge>
             </Avatar>
           </Button>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -5,7 +5,7 @@ import { AppBar, Toolbar, Button, Menu, MenuItem, Avatar, Badge } from "@materia
 import NotificationsIcon from "@material-ui/icons/Notifications";
 import UserContext from "context/UserContext";
 import CodeUploadDialog from 'pages/CodeUploadDialog';
-import axios from "axios";
+// import axios from "axios";
 
 import socket from "utils/socket";
 
@@ -85,37 +85,7 @@ const Navbar = () => {
 
   useEffect(() => {
     socket.connect(localStorage.token);
-
-    // TESTING CODE FOR CREATING A NOTIFICATION
-    // async function createTestNotification() {
-    //   try {
-    //     await axios.post("/api/notifications", {
-    //       recipient: "5e9cab170f8bc650e4b622c8",
-    //       code: 1,
-    //       title: "some title",
-    //     })
-    //   } catch (err) {
-    //     console.error(err);
-    //   }
-    // }
-    // createTestNotification();
-
-    async function getInitialNotifications() {
-      try {
-        const AuthStr = localStorage.token;
-        const { data } = await axios.get("/api/notifications", {
-          headers: { Authorization: "Bearer " + AuthStr },
-        });
-        return data;
-      } catch (err) {
-        console.error(err);
-      }
-    }
-    async function setInitialNotifications() {
-      const data = await getInitialNotifications();
-      setNotifications(data);
-    }
-    setInitialNotifications();
+    socket.fetchNotifications(setNotifications);
   }, []);
 
   console.log(notifications)

--- a/client/src/components/Notifications/Notifications.jsx
+++ b/client/src/components/Notifications/Notifications.jsx
@@ -132,7 +132,7 @@ const Notifications = ({ notifications }) => {
         )) : (
           <MenuItem className={classes.seenMenuItem}>
             <Grid container direction="column">
-              <Typography>No notifications</Typography>
+              <Typography>No notifications.</Typography>
             </Grid>
           </MenuItem>
         )

--- a/client/src/components/Notifications/Notifications.jsx
+++ b/client/src/components/Notifications/Notifications.jsx
@@ -70,14 +70,14 @@ const initialState = {
   ]
 }
 
-const reducer = (state, action) => {
-  switch (action.type) {
-    case "getNotifications":
-      return { ...state, notifications: action.payload};
-    case "newNotification":
-      return { ...state, notifications: [action.payload, ...state.notifications]};
-  }
-}
+// const reducer = (state, action) => {
+//   switch (action.type) {
+//     case "getNotifications":
+//       return { ...state, notifications: action.payload};
+//     case "newNotification":
+//       return { ...state, notifications: [action.payload, ...state.notifications]};
+//   }
+// }
 
 const parseDate = date => {
   const ref = {
@@ -111,15 +111,14 @@ const parseDate = date => {
   }
 };
 
-const Notifications = ({ setNewNotifications }) => {
-  const [state, dispatch] = useReducer(reducer, initialState);
-  const [unreadCount, setUnreadCount] = useState(3);              // TO DO: useState(0)
+const Notifications = ({ notifications }) => {
+  // const [state, dispatch] = useReducer(reducer, initialState);
   const { user } = useContext(UserContext);
   const classes = useStyles();
 
   return (
     <>
-      {state.notifications.map((notification, i) => (
+      {notifications.map((notification, i) => (
         <MenuItem
           key={i}
           className={notification.seen ? classes.seenMenuItem : classes.unseenMenuItem}

--- a/client/src/components/Notifications/Notifications.jsx
+++ b/client/src/components/Notifications/Notifications.jsx
@@ -1,13 +1,10 @@
-import React, { useContext, useState, useReducer } from "react";
+import React from "react";
 import {
   makeStyles,
   MenuItem,
   Grid,
   Typography,
 } from "@material-ui/core";
-import axios from "axios";
-
-import UserContext from "context/UserContext";
 
 const useStyles = makeStyles((theme) => ({
   unseenMenuItem: {
@@ -38,46 +35,6 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "x-small",
   },
 }));
-
-const initialState = {
-  // TO DO: REPLACE THIS MOCK DATA WITH `[]`
-  notifications: [
-    {
-      title: "You have a new review!",
-      date: Date.now() - 7200000,       // 2 hours ago
-      seen: false,
-    },
-    {
-      title: "You have a new review!",
-      date: Date.now() - 604800000,     // 1 week ago
-      seen: true,
-    },
-    {
-      title: "You have a new review!",
-      date: Date.now() - 1209600000,    // 2 weeks (14 days) ago
-      seen: false,
-    },
-    {
-      title: "You have a new review!",
-      date: Date.now() - 2592000000,    // 1 month (30 days) ago
-      seen: false,
-    },
-    {
-      title: "You have a new review!",
-      date: Date.now() - 12960000000,    // 5 months (150 days) ago
-      seen: true,
-    },
-  ]
-}
-
-// const reducer = (state, action) => {
-//   switch (action.type) {
-//     case "getNotifications":
-//       return { ...state, notifications: action.payload};
-//     case "newNotification":
-//       return { ...state, notifications: [action.payload, ...state.notifications]};
-//   }
-// }
 
 const parseDate = date => {
   const ref = {
@@ -112,8 +69,6 @@ const parseDate = date => {
 };
 
 const Notifications = ({ notifications }) => {
-  // const [state, dispatch] = useReducer(reducer, initialState);
-  const { user } = useContext(UserContext);
   const classes = useStyles();
 
   return (

--- a/client/src/components/Notifications/Notifications.jsx
+++ b/client/src/components/Notifications/Notifications.jsx
@@ -118,17 +118,25 @@ const Notifications = ({ notifications }) => {
 
   return (
     <>
-      {notifications.map((notification, i) => (
-        <MenuItem
-          key={i}
-          className={notification.seen ? classes.seenMenuItem : classes.unseenMenuItem}
-        >
-          <Grid container direction="column">
-            <Typography className={classes.notificationTitle}>{notification.title}</Typography>
-            <Typography className={classes.timestamp}>{parseDate(notification.date)}</Typography>
-          </Grid>
-        </MenuItem>
-      ))}
+      {
+        notifications.length ? notifications.map((notification, i) => (
+          <MenuItem
+            key={i}
+            className={notification.seen ? classes.seenMenuItem : classes.unseenMenuItem}
+          >
+            <Grid container direction="column">
+              <Typography className={classes.notificationTitle}>{notification.title}</Typography>
+              <Typography className={classes.timestamp}>{parseDate(notification.date)}</Typography>
+            </Grid>
+          </MenuItem>
+        )) : (
+          <MenuItem className={classes.seenMenuItem}>
+            <Grid container direction="column">
+              <Typography>No notifications</Typography>
+            </Grid>
+          </MenuItem>
+        )
+      }
     </>
   );
 };

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -2,9 +2,35 @@ import React from "react";
 
 import MainContainer from "components/MainContainer";
 
+// REMOVE THESE AFTER TESTING:
+import axios from "axios";
+import { useContext } from "react";
+import UserContext from "context/UserContext";
+
 const Profile = () => {
+
+  const { user } = useContext(UserContext);
+
   return (
     <MainContainer>
+      <button
+        onClick={() => {
+          (async function () {
+            await axios.post("/api/notifications", {
+              reviewId: 1,
+              recipient: {
+                id: `${user.id}`
+              },
+              counterpart: {
+                name: 'some name'
+              },
+              code: 2,
+            })
+          })()
+        }}
+      >
+        TEST
+      </button>
     </MainContainer>
   );
 };

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -2,35 +2,9 @@ import React from "react";
 
 import MainContainer from "components/MainContainer";
 
-// REMOVE THESE AFTER TESTING:
-import axios from "axios";
-import { useContext } from "react";
-import UserContext from "context/UserContext";
-
 const Profile = () => {
-
-  const { user } = useContext(UserContext);
-
   return (
     <MainContainer>
-      <button
-        onClick={() => {
-          (async function () {
-            await axios.post("/api/notifications", {
-              reviewId: 1,
-              recipient: {
-                id: `${user.id}`
-              },
-              counterpart: {
-                name: 'some name'
-              },
-              code: 2,
-            })
-          })()
-        }}
-      >
-        TEST
-      </button>
     </MainContainer>
   );
 };

--- a/client/src/utils/socket.js
+++ b/client/src/utils/socket.js
@@ -1,5 +1,5 @@
 import io from "socket.io-client";
-// import axios from "axios";
+import axios from "axios";
 
 class Socket {
   async connect(token) {
@@ -12,6 +12,18 @@ class Socket {
     this.socket.on("notification", data => {
       console.log(`notification received: ${data}`);  // TO DO: figure out what happens next?
     });
+  }
+
+  async fetchNotifications(setNotifications) {
+    const AuthStr = localStorage.token;
+    try {
+      const { data } = await axios.get("/api/notifications", {
+        headers: { Authorization: "Bearer " + AuthStr },
+      })
+      setNotifications(data);
+    } catch (err) {
+      console.error(err);
+    }
   }
 }
 

--- a/client/src/utils/socket.js
+++ b/client/src/utils/socket.js
@@ -2,7 +2,7 @@ import io from "socket.io-client";
 import axios from "axios";
 
 class Socket {
-  async connect(token) {
+  connect(token, setNewNotification) {
     this.socket = io("localhost:3001");
 
     // emit event with token from localStorage (will be verified in back end with JWT)
@@ -10,17 +10,17 @@ class Socket {
 
     // receive notification from server
     this.socket.on("notification", data => {
-      console.log(`notification received: ${data}`);  // TO DO: figure out what happens next?
+      setNewNotification(data);
     });
   }
 
-  async fetchNotifications(setNotifications) {
+  async fetchNotifications() {
     const AuthStr = localStorage.token;
     try {
       const { data } = await axios.get("/api/notifications", {
         headers: { Authorization: "Bearer " + AuthStr },
       })
-      setNotifications(data);
+      return data;
     } catch (err) {
       console.error(err);
     }

--- a/server/controllers/notifications.js
+++ b/server/controllers/notifications.js
@@ -1,0 +1,18 @@
+const Notification = require("../models/Notification");
+const User = require("../models/User");
+const Socket = require("../services/socket");
+
+const createNotification = async data => {
+  const notification = await new Notification(data);
+  // TO DO: EMIT A SOCKET
+  return await notification.save();
+};
+
+const getNotifications = async recipient => {
+  return await Notification.find({ recipient });
+};
+
+module.exports = {
+  createNotification,
+  getNotifications,
+};

--- a/server/controllers/notifications.js
+++ b/server/controllers/notifications.js
@@ -1,10 +1,55 @@
 const Notification = require("../models/Notification");
-const User = require("../models/User");
 const Socket = require("../services/socket");
 
+/*
+NOTIFICATION CODES:
+1 - you have been assigned to do a review
+2 - your request has been matched with someone
+3 - your reviewer has accepted your request
+4 - your reviewer has declined your request
+5 - your reviewer has completed your request
+6 - your requestor has made a new post in the thread
+7 - your reviewer has made a new post in the thread
+*/
+
 const createNotification = async data => {
-  const notification = await new Notification(data);
-  // TO DO: EMIT A SOCKET
+  const { reviewId, recipient, counterpart, code } = data;
+  const body = { recipient: recipient.id };
+  switch (code) {
+    case 1:
+      body.title = `${counterpart.name} has requested your review!`;
+      body.link = `reviews/${reviewId}`;
+      break;
+    case 2:
+      body.title = `Your request has been matched with ${counterpart.name}!`;
+      body.link = `requests/${reviewId}`;
+      break;
+    case 3:
+      body.title = `${counterpart.name} has accepted your request!`;
+      body.link = `requests/${reviewId}`;
+      break;
+    case 4:
+      body.title = `${counterpart.name} has declined your request.`;
+      body.link = `requests/${reviewId}`;
+      break;
+    case 5:
+      body.title = `${counterpart.name} has completed your request!`;
+      body.link = `requests/${reviewId}`;
+      break;
+    case 6:
+      body.title = `${counterpart.name} made a post in your thread!`;
+      body.link = `reviews/${reviewId}`;
+      break;
+    case 7:
+      body.title = `${counterpart.name} made a post in your thread!`;
+      body.link = `requests/${reviewId}`;
+      break;
+    default:
+      body.title = "";
+      body.link = "";
+  }
+  const notification = await new Notification(body);
+  Socket.sendNotification(notification);
   return await notification.save();
 };
 

--- a/server/controllers/notifications.js
+++ b/server/controllers/notifications.js
@@ -1,46 +1,38 @@
 const Notification = require("../models/Notification");
 const Socket = require("../services/socket");
 
-/*
-NOTIFICATION CODES:
-1 - you have been assigned to do a review
-2 - your request has been matched with someone
-3 - your reviewer has accepted your request
-4 - your reviewer has declined your request
-5 - your reviewer has completed your request
-6 - your requestor has made a new post in the thread
-7 - your reviewer has made a new post in the thread
-*/
+const RECEIVED_REVIEW_REQUEST = 1;
+const REQUEST_ACCEPTED = 2;
+const REQUEST_DECLINED = 3;
+const REVIEW_COMPLETED = 4;
+const REQUESTOR_NEW_POST = 5;
+const REVIEWER_NEW_POST = 6;
 
 const createNotification = async data => {
   const { reviewId, recipient, counterpart, code } = data;
   const body = { recipient: recipient.id };
   switch (code) {
-    case 1:
+    case RECEIVED_REVIEW_REQUEST:
       body.title = `${counterpart.name} has requested your review!`;
       body.link = `reviews/${reviewId}`;
       break;
-    case 2:
-      body.title = `Your request has been matched with ${counterpart.name}!`;
-      body.link = `requests/${reviewId}`;
-      break;
-    case 3:
+    case REQUEST_ACCEPTED:
       body.title = `${counterpart.name} has accepted your request!`;
       body.link = `requests/${reviewId}`;
       break;
-    case 4:
+    case REQUEST_DECLINED:
       body.title = `${counterpart.name} has declined your request.`;
       body.link = `requests/${reviewId}`;
       break;
-    case 5:
-      body.title = `${counterpart.name} has completed your request!`;
+    case REVIEW_COMPLETED:
+      body.title = `${counterpart.name} has marked the review complete!`;
       body.link = `requests/${reviewId}`;
       break;
-    case 6:
+    case REQUESTOR_NEW_POST:
       body.title = `${counterpart.name} made a post in your thread!`;
       body.link = `reviews/${reviewId}`;
       break;
-    case 7:
+    case REVIEWER_NEW_POST:
       body.title = `${counterpart.name} made a post in your thread!`;
       body.link = `requests/${reviewId}`;
       break;

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -6,7 +6,7 @@ const notificationSchema = new Schema({
   recipient: { type: ObjectId, required: true },
   code: Number,
   title: String,  // "you have a new request from {user name}!"
-  date: { type: Date, default: Date.now },  // epoch time integer
+  date: { type: Number, default: Date.now() },  // epoch time integer
   link: String, // request or review? requests/:reviewId or reviews/:reviewId
   seen: { type: Boolean, default: false },
 });

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -4,10 +4,9 @@ const { Schema, ObjectId } = mongoose;
 
 const notificationSchema = new Schema({
   recipient: { type: ObjectId, required: true },
-  code: Number,
-  title: String,  // "you have a new request from {user name}!"
-  date: { type: Number, default: Date.now() },  // epoch time integer
-  link: String, // request or review? requests/:reviewId or reviews/:reviewId
+  title: String,
+  link: String,
+  date: { type: Number, default: Date.now },
   seen: { type: Boolean, default: false },
 });
 

--- a/server/routes/api/notifications.js
+++ b/server/routes/api/notifications.js
@@ -1,8 +1,6 @@
 const { Router } = require("express");
 
 const authenticate = require("../../middlewares/authenticate");
-const Notification = require("../../models/Notification");
-const Socket = require("../../services/socket");
 const {
   createNotification,
   getNotifications,

--- a/server/routes/api/notifications.js
+++ b/server/routes/api/notifications.js
@@ -3,14 +3,28 @@ const { Router } = require("express");
 const authenticate = require("../../middlewares/authenticate");
 const Notification = require("../../models/Notification");
 const Socket = require("../../services/socket");
+const {
+  createNotification,
+  getNotifications,
+} = require("../../controllers/notifications");
 
 const router = Router();
 
 // get all notifications for a specified userId
 router.get("/", authenticate, async (req, res) => {
   try {
-    const recipient = req.user.id;
-    res.status(200).send(await Notification.find({ recipient }));
+    const notificationData = await getNotifications(req.user.id);
+    res.status(200).send(notificationData);
+  } catch (err) {
+    console.error(err);
+    res.sendStatus(500);
+  }
+});
+
+router.post("/", async(req, res) => {
+  try {
+    const notification = await createNotification(req.body);
+    res.status(200).send(notification);
   } catch (err) {
     console.error(err);
     res.sendStatus(500);

--- a/server/services/MatchQueue/matchQueueProcessor.js
+++ b/server/services/MatchQueue/matchQueueProcessor.js
@@ -1,5 +1,8 @@
 const Review = require("../../models/Review");
 const User = require("../../models/User");
+const {
+  createNotification,
+} = require("../../controllers/notifications");
 
 const matchQueueProcessor = async (job) => {
   const { reviewId } = job.data;
@@ -48,10 +51,26 @@ const matchQueueProcessor = async (job) => {
 
   // select random reviewer from pool and assign to review
   if (reviewerPool.length >= 1) {
-    const reviewer =
-      reviewerPool[Math.floor(Math.random() * reviewerPool.length)];
+    const reviewer = reviewerPool[
+      Math.floor(Math.random() * reviewerPool.length)
+    ];
     review.reviewerId = reviewer.id;
+    // send a notification to the assigned reviewer
+    await createNotification({
+      reviewId,
+      recipient: reviewer,
+      counterpart: requester,
+      code: 1,
+    });
+    // send a notification to the requestor
+    await createNotification({
+      reviewId,
+      recipient: requester,
+      counterpart: reviewer,
+      code: 2,
+    });
   }
+
   // update document even if no match
   await review.save();
 

--- a/server/services/MatchQueue/matchQueueProcessor.js
+++ b/server/services/MatchQueue/matchQueueProcessor.js
@@ -60,14 +60,14 @@ const matchQueueProcessor = async (job) => {
       reviewId,
       recipient: reviewer,
       counterpart: requester,
-      code: 1,
+      code: 0,
     });
     // send a notification to the requestor
     await createNotification({
       reviewId,
       recipient: requester,
       counterpart: reviewer,
-      code: 2,
+      code: 1,
     });
   }
 

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -42,7 +42,6 @@ class Socket {
     const { recipient } = data;
     const recipientSocketId = this.usersByUserId[recipient];
     this.io.to(recipientSocketId).emit("notification", data);
-    console.log("WHAT IS THE DATA (SERVER)?", data)
   }
 }
 

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -38,8 +38,11 @@ class Socket {
   }
 
   // send notification to specific user (via user's unique room)
-  sendNotification(userId, data) {
-    this.io.to(userId).emit("notification", data);
+  sendNotification(data) {
+    const { recipient } = data;
+    const recipientSocketId = this.usersByUserId[recipient];
+    this.io.to(recipientSocketId).emit("notification", data);
+    console.log("WHAT IS THE DATA (SERVER)?", data)
   }
 }
 


### PR DESCRIPTION
- created notification controller
- updated notification schema
- navbar now fetches all notification data for a user, on mount
- integrated sockets to send new notifications to users in real time

hollow notification bell says "No notifications." when none exist for user:
![ss1](https://user-images.githubusercontent.com/45887253/79709606-a26a5300-8290-11ea-9473-efb4d9f893bc.png)

after a user submits code for review, once a match happens, a new notification is generated in the db, and a socket sends the new notification to both parties. the notification bell fills when at least 1 notification exists for a user (the green circle also lights up when there is at least 1 UNREAD notification for a user):
![ss2](https://user-images.githubusercontent.com/45887253/79709608-a26a5300-8290-11ea-8f13-05393aa39c9d.png)

this is what the requestor sees when clicking the bell:
![ss3](https://user-images.githubusercontent.com/45887253/79709609-a26a5300-8290-11ea-83b8-35c76b2e068f.png)

the reviewer also sees a corresponding notification:
![ss4](https://user-images.githubusercontent.com/45887253/79709610-a302e980-8290-11ea-8e77-feeab1752f30.png)

TO DO:
- when clicking a notification, it should become unread (and no longer highlighted in green), and the browser should go to the corresponding link
- each notification should have an X in the corner, and clicking upon it should delete it from the database
